### PR TITLE
Laravel 6+ support and auto discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
 	],
 	"require": {
 		"php": "^5.3.3 || >=7.0",
-		"illuminate/database": "~5.1",
-		"illuminate/support": "~5.1"
+		"illuminate/database": "~5.1 || >= 6.0",
+		"illuminate/support": "~5.1 || >= 6.0"
 	},
 	"autoload": {
 		"classmap": [

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,12 @@
 		"classmap": [
 			"src"
 		]
+	},
+	"extra": {
+		"laravel": {
+			"providers": [
+				"Abram\\Odbc\\ODBCServiceProvider"
+			]
+		}
 	}
 }

--- a/src/ODBCConnector.php
+++ b/src/ODBCConnector.php
@@ -27,7 +27,7 @@ class ODBCConnector extends Connector implements ConnectorInterface
     {
         $options = $this->getOptions($config);
 
-        $dsn = array_get($config, 'dsn');
+        $dsn = Arr::get($config, 'dsn');
 
         $connection = $this->createConnection($dsn, $config, $options);
 

--- a/src/ODBCConnector.php
+++ b/src/ODBCConnector.php
@@ -10,6 +10,7 @@ namespace Abram\Odbc;
 
 use Illuminate\Database\Connectors\Connector;
 use Illuminate\Database\Connectors\ConnectorInterface;
+use Illuminate\Support\Arr;
 
 class ODBCConnector extends Connector implements ConnectorInterface
 {


### PR DESCRIPTION
This PR adds Laravel 6 and higher support and provides auto discover functionality for Laravel 5.5+